### PR TITLE
Change date format on parent components props with default value

### DIFF
--- a/src/GGanttChart.vue
+++ b/src/GGanttChart.vue
@@ -7,6 +7,7 @@
       v-if="!hideTimeaxis"
       :chart-start="chartStart"
       :chart-end="chartEnd"
+      :day-format="dayFormat"
       :row-label-width="rowLabelWidth"
       :timemarker-offset="timemarkerOffset"
       :theme-colors="themeColors"
@@ -46,6 +47,7 @@ export default {
   },
 
   props:{
+    dayFormat: {type: String, default: "dddd, DD. MMMM"},
     chartStart: {type: String, default: moment().startOf("day").format("YYYY-MM-DD HH:mm:ss")},
     chartEnd: {type: String, default: moment().startOf("day").add(12,"hours").format("YYYY-MM-DD HH:mm:ss")},
     hideTimeaxis: Boolean,
@@ -284,6 +286,7 @@ export default {
   provide(){
     return {
       getChartStart: () => this.chartStart,
+      getDayFormat: () => this.dayFormat,
       getChartEnd: () => this.chartEnd,
       getHourCount: () => this.hourCount,
       ganttChartProps: this.$props,

--- a/src/GGanttRow.vue
+++ b/src/GGanttRow.vue
@@ -69,6 +69,7 @@ export default {
     "getThemeColors",
     "getHourCount",
     "getChartStart",
+    "getDayFormat",
     "getChartEnd"
   ],
 

--- a/src/GGanttTimeaxis.vue
+++ b/src/GGanttTimeaxis.vue
@@ -49,6 +49,7 @@ export default {
   name:"GGanttTimeaxis",
 
   props: {
+    dayFormat: {type: String, default: "dddd, DD. MMMM"},
     chartStart: String,
     chartEnd: String,
     rowLabelWidth: String,
@@ -62,8 +63,7 @@ export default {
       axisDays: [],
       hourCount: null,
       timemarker: null,
-      hourFontSize: "11px",
-      dayFormat: "dddd, DD. MMMM"
+      hourFontSize: "11px"
     }
   },
 


### PR DESCRIPTION
This change can be used to dynamize the date formats by sending directly in props in the component GantChart `:day-format="value"`

This props has a default value and is not required, no change is required if the lib is update.

By default the value is: `"dddd, DD. MMMM" string` <-- recover from the data


cordially.
