### PR TITLE
feat: expose date value to timeunit slots

### DIFF
--- a/src/components/GGanttChart.vue
+++ b/src/components/GGanttChart.vue
@@ -5,13 +5,13 @@
     :style="{ width, background: colors.background, fontFamily: font }"
   >
     <g-gantt-timeaxis v-if="!hideTimeaxis">
-      <template #upper-timeunit="{ label, value }">
+      <template #upper-timeunit="{ label, value, date }">
         <!-- expose upper-timeunit slot of g-gantt-timeaxis-->
-        <slot name="upper-timeunit" :label="label" :value="value" />
+        <slot name="upper-timeunit" :label="label" :value="value" :date="date" />
       </template>
-      <template #timeunit="{ label, value }">
+      <template #timeunit="{ label, value, date }">
         <!-- expose timeunit slot of g-gantt-timeaxis-->
-        <slot name="timeunit" :label="label" :value="value" />
+        <slot name="timeunit" :label="label" :value="value" :date="date" />
       </template>
     </g-gantt-timeaxis>
 

--- a/src/components/GGanttTimeaxis.vue
+++ b/src/components/GGanttTimeaxis.vue
@@ -2,7 +2,7 @@
   <div class="g-timeaxis">
     <div class="g-timeunits-container">
       <div
-        v-for="({ label, value, width }, index) in timeaxisUnits.upperUnits"
+        v-for="({ label, value, date, width }, index) in timeaxisUnits.upperUnits"
         :key="label"
         class="g-upper-timeunit"
         :style="{
@@ -11,7 +11,7 @@
           width
         }"
       >
-        <slot name="upper-timeunit" :label="label" :value="value">
+        <slot name="upper-timeunit" :label="label" :value="value" :date="date">
           {{ label }}
         </slot>
       </div>
@@ -19,7 +19,7 @@
 
     <div class="g-timeunits-container">
       <div
-        v-for="({ label, value, width }, index) in timeaxisUnits.lowerUnits"
+        v-for="({ label, value, date, width }, index) in timeaxisUnits.lowerUnits"
         :key="label"
         class="g-timeunit"
         :style="{
@@ -30,7 +30,7 @@
           width
         }"
       >
-        <slot name="timeunit" :label="label" :value="value">
+        <slot name="timeunit" :label="label" :value="value" :date="date">
           {{ label }}
         </slot>
         <div

--- a/src/composables/useTimeaxisUnits.ts
+++ b/src/composables/useTimeaxisUnits.ts
@@ -32,8 +32,8 @@ export default function useTimeaxisUnits() {
   }
 
   const timeaxisUnits = computed(() => {
-    const upperUnits: { label: string; value?: string; width?: string }[] = []
-    const lowerUnits: { label: string; value?: string; width?: string }[] = []
+    const upperUnits: { label: string; value?: string; date?: Date, width?: string }[] = []
+    const lowerUnits: { label: string; value?: string; date?: Date, width?: string }[] = []
     const upperUnit = upperPrecision.value === "day" ? "date" : upperPrecision.value
     const lowerUnit = precision.value
     let currentUnit = chartStartDayjs.value.startOf(lowerUnit)
@@ -63,11 +63,11 @@ export default function useTimeaxisUnits() {
           const start = currentUnit.subtract(1, upperUnit as ManipulateType).startOf(upperUnit)
           width = (end.diff(start, "minutes", true) / totalMinutes) * 100
         }
+        const resultDayjs = currentUnit.subtract(1, upperUnit as ManipulateType)
         upperUnits.push({
-          label: currentUnit
-            .subtract(1, upperUnit as ManipulateType)
-            .format(displayFormats[upperUnit]),
+          label: resultDayjs.format(displayFormats[upperUnit]),
           value: String(currentUpperUnitVal),
+          date: resultDayjs.toDate(),
           width: String(width) + "%"
         })
         upperUnitMinutesCount = 0
@@ -94,6 +94,7 @@ export default function useTimeaxisUnits() {
       lowerUnits.push({
         label: currentUnit.format(displayFormats[lowerUnit]),
         value: String(currentUnit[lowerUnit === "day" ? "date" : lowerUnit]()),
+        date: currentUnit.toDate(),
         width: String(width) + "%"
       })
       const prevUpperUnitUnit = currentUnit
@@ -117,6 +118,7 @@ export default function useTimeaxisUnits() {
       upperUnits.push({
         label: chartEndDayjs.value.format(displayFormats[upperUnit]),
         value: String(currentUpperUnitVal),
+        date: chartEndDayjs.value.toDate(),
         width: `${(upperUnitMinutesCount / totalMinutes) * 100}%`
       })
     }


### PR DESCRIPTION
By providing the date value we make it easy to let the user decide how to format the value. E.g. we wanted to show the date in a separate line from the weekday. Making it possible to provide a formatting option for the timeunit slots would also not suffice, since we then still couldn't format date and weekday differently.